### PR TITLE
Update URL shown after deploying to Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/alexa-js/alexa-app-example",
   "logo": "https://avatars0.githubusercontent.com/u/25057028",
   "keywords": ["alexa", "amazon", "echo", "skills"],
+  "success_url": "/test",
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
This sends the user to `https://APP-NAME/test` after initial deploy to Heroku. The `/test` path is specified in the docs so I thought I'd add it to the button to make a smoother experience for first-time deployers!